### PR TITLE
Allow to make calling code separate from phone input

### DIFF
--- a/docs/docs/api-reference.md
+++ b/docs/docs/api-reference.md
@@ -60,6 +60,17 @@ Force the calling code (e.g: +33) to be displayed so the value cannot be empty.
 <MuiTelInput forceCallingCode />
 ```
 
+## `splitCallingCode`
+
+- Type: `boolean`
+- Default: `false`
+
+Displays the calling code (e.g: +33) as read-only next to the flag and with a divider instead of as part of the input field.
+
+```tsx
+<MuiTelInput splitCallingCode />
+```
+
 ## `focusOnSelectCountry`
 
 - Type: `boolean`

--- a/src/components/FlagButton/FlagButton.tsx
+++ b/src/components/FlagButton/FlagButton.tsx
@@ -1,51 +1,74 @@
 import React from 'react'
 import Flag from '@components/Flag/Flag'
+import { Typography } from '@mui/material'
 import IconButton, { IconButtonProps } from '@mui/material/IconButton'
 import type { MuiTelInputCountry } from '@shared/constants/countries'
+import { getCallingCodeOfCountry } from '@shared/helpers/country'
 
 export type FlagButtonProps = IconButtonProps & {
   isoCode: MuiTelInputCountry | null
+  splitCallingCode?: boolean
   isFlagsMenuOpened: boolean
   disableDropdown?: boolean
 }
 
 const FlagButton = (props: FlagButtonProps) => {
-  const { isoCode, isFlagsMenuOpened, disableDropdown, ...iconButtonProps } =
-    props
-
-  if (disableDropdown) {
-    return (
-      <IconButton
-        tabIndex={-1}
-        className="MuiTelInput-IconButton"
-        // eslint-disable-next-line jsx-a11y/aria-role
-        role=""
-        disableRipple
-        // @ts-ignore
-        sx={{ pointerEvents: 'none' }}
-        component="span"
-      >
-        <Flag isoCode={isoCode} />
-      </IconButton>
-    )
-  }
+  const {
+    isoCode,
+    isFlagsMenuOpened,
+    disableDropdown,
+    splitCallingCode,
+    ...iconButtonProps
+  } = props
 
   return (
-    <IconButton
-      {...iconButtonProps}
-      aria-label="Select country"
-      className="MuiTelInput-IconButton"
-      aria-haspopup="listbox"
-      aria-controls={isFlagsMenuOpened ? 'select-country' : undefined}
-      aria-expanded={isFlagsMenuOpened ? 'true' : 'false'}
-    >
-      <Flag isoCode={isoCode} />
-    </IconButton>
+    <>
+      {disableDropdown ? (
+        <IconButton
+          tabIndex={-1}
+          className="MuiTelInput-IconButton"
+          // eslint-disable-next-line jsx-a11y/aria-role
+          role=""
+          disableRipple
+          // @ts-ignore
+          sx={{ pointerEvents: 'none' }}
+          component="span"
+        >
+          <Flag isoCode={isoCode} />
+        </IconButton>
+      ) : (
+        <IconButton
+          {...iconButtonProps}
+          aria-label="Select country"
+          className="MuiTelInput-IconButton"
+          aria-haspopup="listbox"
+          aria-controls={isFlagsMenuOpened ? 'select-country' : undefined}
+          aria-expanded={isFlagsMenuOpened ? 'true' : 'false'}
+        >
+          <Flag isoCode={isoCode} />
+        </IconButton>
+      )}
+
+      {splitCallingCode && isoCode ? (
+        <Typography
+          sx={{
+            pr: 1,
+            cursor: 'default',
+            borderRightWidth: 1,
+            borderRightColor: 'grey.300',
+            borderRightStyle: 'solid'
+          }}
+        >
+          +{getCallingCodeOfCountry(isoCode)}
+        </Typography>
+      ) : null}
+    </>
   )
 }
 
 FlagButton.defaultProps = {
-  disableDropdown: false
+  disableDropdown: false,
+  splitCallingCode: false
 }
 
 export default FlagButton

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -380,12 +380,12 @@ describe('components/MuiTelInput', () => {
     expect(result).toBe('+33 6 26 92 26 31')
   })
 
-  test('should display the new calling of the new selected country flag', async () => {
-    render(<MuiTelWrapper />)
+  test('should display the new calling of the new selected country flag, keeping original number', async () => {
+    render(<MuiTelWrapper disableFormatting />)
     await typeInInputElement('+33626922631')
     expectButtonIsFlagOf('FR')
     selectCountry('BE')
-    expect(getInputElement().value).toBe('+32')
+    expect(getInputElement().value).toBe('+32626922631')
     expectButtonIsFlagOf('BE')
   })
 
@@ -414,6 +414,47 @@ describe('components/MuiTelInput', () => {
     rerender(<MuiTelWrapper defaultCountry="FR" value="" />)
     expect(getInputElement().value).toBe('+33')
     expectButtonIsFlagOf('FR')
+  })
+
+  test('should not have calling code if splitting it', () => {
+    render(
+      <MuiTelWrapper
+        defaultCountry="ES"
+        splitCallingCode
+        disableFormatting
+        value="+34555123456"
+      />
+    )
+    expect(getInputElement().value).toBe('555123456')
+    expectButtonIsFlagOf('ES')
+  })
+
+  test('should not allow inputting a calling code if splitting it', async () => {
+    render(
+      <MuiTelWrapper splitCallingCode disableFormatting defaultCountry="ES" />
+    )
+    await typeInInputElement('+33555123456')
+    expect(getInputElement().value).toBe('33555123456')
+    expectButtonIsFlagOf('ES')
+  })
+
+  test('should give calling code in onchange info even when splitting it', async () => {
+    const callbackOnChange = vi.fn(() => {})
+    render(
+      <MuiTelWrapper
+        splitCallingCode
+        defaultCountry="ES"
+        onChange={callbackOnChange}
+      />
+    )
+    await typeInInputElement('555123456')
+    expect(callbackOnChange).toHaveBeenCalledWith('555 12 34 56', {
+      countryCallingCode: '34',
+      countryCode: 'ES',
+      nationalNumber: '555123456',
+      numberValue: '+34555123456',
+      reason: 'input'
+    })
   })
 
   /** Copy doesn't work in user-event@beta */

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -32,6 +32,7 @@ const MuiTelInput = React.forwardRef(
   (props: MuiTelInputProps, propRef: MuiTelInputProps['ref']) => {
     const {
       forceCallingCode,
+      splitCallingCode,
       onlyCountries,
       excludedCountries,
       defaultCountry,
@@ -65,6 +66,7 @@ const MuiTelInput = React.forwardRef(
         value: value ?? '',
         onChange,
         forceCallingCode,
+        splitCallingCode,
         excludedCountries,
         onlyCountries,
         disableFormatting,
@@ -179,6 +181,7 @@ const MuiTelInput = React.forwardRef(
                   onClick={handleOpenFlagsMenu}
                   disabled={disabled}
                   disableDropdown={Boolean(disableDropdown)}
+                  splitCallingCode={splitCallingCode}
                 />
               </InputAdornment>
             )

--- a/src/index.types.ts
+++ b/src/index.types.ts
@@ -26,6 +26,7 @@ export interface MuiTelInputProps extends BaseTextFieldProps {
   preferredCountries?: MuiTelInputCountry[]
   defaultCountry?: MuiTelInputCountry
   forceCallingCode?: boolean
+  splitCallingCode?: boolean
   focusOnSelectCountry?: boolean
   disableDropdown?: boolean
   langOfCountryName?: string


### PR DESCRIPTION
As requested in https://github.com/viclafouch/mui-tel-input/issues/27

Looks like this:

![image](https://user-images.githubusercontent.com/690217/200687569-608c2e25-db99-4afb-aa27-84517f5c478a.png)




Also preserves the number when changing countries, instead of clearing the field, as per https://github.com/viclafouch/mui-tel-input/issues/24