### PR TITLE
Default to US if splitting calling code and no default country provided

### DIFF
--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -457,6 +457,11 @@ describe('components/MuiTelInput', () => {
     })
   })
 
+  test('should default to US country if splitting calling code and no default country provided', () => {
+    render(<MuiTelWrapper splitCallingCode />)
+    expectButtonIsFlagOf('US')
+  })
+
   /** Copy doesn't work in user-event@beta */
   // test('should fire the onCopy prop', async () => {
   //   const user = userEvent.setup({

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -62,7 +62,7 @@ const MuiTelInput = React.forwardRef(
 
     const { onInputChange, onCountryChange, inputRef, isoCode, inputValue } =
       usePhoneDigits({
-        defaultCountry,
+        defaultCountry: defaultCountry || (splitCallingCode ? 'US' : undefined),
         value: value ?? '',
         onChange,
         forceCallingCode,

--- a/src/shared/hooks/useMissmatchProps.ts
+++ b/src/shared/hooks/useMissmatchProps.ts
@@ -5,7 +5,13 @@ import { log } from '@shared/helpers/log'
 import { MuiTelInputProps } from '../../index.types'
 
 export function useMismatchProps(props: MuiTelInputProps) {
-  const { defaultCountry, onlyCountries, excludedCountries, continents } = props
+  const {
+    defaultCountry,
+    onlyCountries,
+    excludedCountries,
+    continents,
+    splitCallingCode
+  } = props
 
   React.useEffect(() => {
     if (onlyCountries && excludedCountries) {
@@ -53,4 +59,12 @@ export function useMismatchProps(props: MuiTelInputProps) {
       }
     }
   }, [defaultCountry, continents])
+
+  React.useEffect(() => {
+    if (splitCallingCode && !defaultCountry) {
+      log(
+        `[mui-tel-input] 'splitCallingCode' needs 'defaultCountry' defined. Will default to US.`
+      )
+    }
+  }, [defaultCountry, splitCallingCode])
 }


### PR DESCRIPTION
I think it doesn't really make sense to split the calling code without a default country (as the user can not input the calling code when it's split), so I think this is the most acceptable solution:

- Output the need to use a default country in the console.
- Default to US calling code.


https://github.com/viclafouch/mui-tel-input/pull/28#issuecomment-1312750059
