### PR TITLE
feat: Add phone number type to MuiTelInputInfo

### DIFF
--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -148,6 +148,7 @@ describe('components/MuiTelInput', () => {
         countryCallingCode: '33',
         countryCode: 'FR',
         nationalNumber: '626',
+        numberType: null,
         numberValue: '+33626',
         reason: 'input'
       })
@@ -187,6 +188,7 @@ describe('components/MuiTelInput', () => {
         countryCallingCode: '32',
         countryCode: 'BE',
         nationalNumber: '',
+        numberType: null,
         numberValue: '+32',
         reason: 'country'
       })
@@ -200,6 +202,7 @@ describe('components/MuiTelInput', () => {
         countryCallingCode: '32',
         countryCode: 'BE',
         nationalNumber: '',
+        numberType: null,
         numberValue: '+32',
         reason: 'country'
       })
@@ -242,6 +245,7 @@ describe('components/MuiTelInput', () => {
         countryCallingCode: '33',
         countryCode: 'FR',
         nationalNumber: '626',
+        numberType: null,
         numberValue: '+33626',
         reason: 'input'
       })
@@ -452,6 +456,7 @@ describe('components/MuiTelInput', () => {
       countryCallingCode: '34',
       countryCode: 'ES',
       nationalNumber: '555123456',
+      numberType: null,
       numberValue: '+34555123456',
       reason: 'input'
     })

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -18,7 +18,8 @@ import type {
 
 export {
   isValidPhoneNumber as matchIsValidTel,
-  AsYouType
+  AsYouType,
+  getNumberType
 } from 'libphonenumber-js'
 
 export type {

--- a/src/index.types.ts
+++ b/src/index.types.ts
@@ -16,6 +16,7 @@ export interface MuiTelInputInfo {
   countryCode: MuiTelInputCountry | null
   countryCallingCode: string | null
   nationalNumber: string | null
+  numberType: string | null
   numberValue: string | null
   reason: MuiTelInputReason
 }

--- a/src/shared/hooks/usePhoneDigits.ts
+++ b/src/shared/hooks/usePhoneDigits.ts
@@ -1,5 +1,5 @@
 import React from 'react'
-import { AsYouType } from 'libphonenumber-js'
+import { AsYouType, getNumberType } from 'libphonenumber-js'
 import { MuiTelInputContinent } from '@shared/constants/continents'
 import { COUNTRIES, MuiTelInputCountry } from '@shared/constants/countries'
 import { matchIsArray } from '@shared/helpers/array'
@@ -126,6 +126,11 @@ export default function usePhoneDigits({
       countryCallingCode: asYouTypeRef.current.getCallingCode() || null,
       countryCode: asYouTypeRef.current.getCountry() || null,
       nationalNumber: asYouTypeRef.current.getNationalNumber(),
+      numberType:
+        getNumberType(
+          asYouTypeRef.current.getNationalNumber(),
+          asYouTypeRef.current.getCountry()
+        ) || null,
       numberValue: asYouTypeRef.current.getNumberValue() || null,
       reason
     }


### PR DESCRIPTION
Add NumberType to MuiTelInputInfo

- Allows users to access further information about the type of number being entered i.e. MOBILE, LANDLINE etc.