### PR TITLE
fix: add aria on Flag inside FlagButton

### DIFF
--- a/src/components/FlagButton/FlagButton.test.tsx
+++ b/src/components/FlagButton/FlagButton.test.tsx
@@ -5,17 +5,26 @@ import '@testing-library/jest-dom'
 
 describe('components/FlagButton', () => {
   test('should have aria-expanded to true', () => {
-    render(<FlagButton isFlagsMenuOpened isoCode="FR" />)
+    render(<FlagButton isFlagsMenuOpened isoCode="FR" countryName="France" />)
     expect(screen.getByRole('button')).toHaveAttribute('aria-expanded', 'true')
   })
 
   test('should have aria-expanded to false', () => {
-    render(<FlagButton isFlagsMenuOpened={false} isoCode="FR" />)
+    render(
+      <FlagButton isFlagsMenuOpened={false} isoCode="FR" countryName="France" />
+    )
     expect(screen.getByRole('button')).toHaveAttribute('aria-expanded', 'false')
   })
 
   test('should be disabled', () => {
-    render(<FlagButton disabled isFlagsMenuOpened={false} isoCode="FR" />)
+    render(
+      <FlagButton
+        disabled
+        isFlagsMenuOpened={false}
+        isoCode="FR"
+        countryName="France"
+      />
+    )
     expect(screen.getByRole('button')).toBeDisabled()
   })
 })

--- a/src/components/FlagButton/FlagButton.tsx
+++ b/src/components/FlagButton/FlagButton.tsx
@@ -8,6 +8,7 @@ import { Styled } from './FlagButton.styled'
 
 export type FlagButtonProps = IconButtonProps & {
   isoCode: MuiTelInputCountry | null
+  countryName: string | undefined
   forceCallingCode?: boolean
   isFlagsMenuOpened: boolean
   disableDropdown?: boolean
@@ -20,6 +21,7 @@ const FlagButton = ({
   flagSize = 'small',
   isFlagsMenuOpened = false,
   isoCode,
+  countryName,
   ...iconButtonProps
 }: FlagButtonProps) => {
   return (
@@ -35,7 +37,7 @@ const FlagButton = ({
           sx={{ pointerEvents: 'none', aspectRatio: '1 / 1' }}
           component="span"
         >
-          <Flag size={flagSize} isoCode={isoCode} />
+          <Flag size={flagSize} isoCode={isoCode} countryName={countryName} />
         </IconButton>
       ) : (
         <IconButton
@@ -47,7 +49,7 @@ const FlagButton = ({
           aria-controls={isFlagsMenuOpened ? 'select-country' : undefined}
           aria-expanded={isFlagsMenuOpened ? 'true' : 'false'}
         >
-          <Flag size={flagSize} isoCode={isoCode} />
+          <Flag size={flagSize} isoCode={isoCode} countryName={countryName} />
         </IconButton>
       )}
       {forceCallingCode && isoCode ? (

--- a/src/components/FlagsMenu/FlagsMenu.test.tsx
+++ b/src/components/FlagsMenu/FlagsMenu.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { expect, vi } from 'vitest'
 import { ISO_CODES, MuiTelInputCountry } from '@shared/constants/countries'
+import { getDisplayNames } from '@shared/helpers/intl'
 import { fireEvent, render, screen } from '@testing-library/react'
 import FlagsMenu from './FlagsMenu'
 import '@testing-library/jest-dom'
@@ -17,6 +18,7 @@ describe('components/FlagsMenu', () => {
   test('should displayed when anchorEl is valid', () => {
     render(
       <FlagsMenu
+        displayNames={getDisplayNames()}
         anchorEl={getAnchorEl()}
         isoCode="FR"
         onSelectCountry={() => {}}
@@ -27,6 +29,7 @@ describe('components/FlagsMenu', () => {
   test('should render correctly', () => {
     render(
       <FlagsMenu
+        displayNames={getDisplayNames()}
         isoCode="FR"
         excludedCountries={['FR']}
         onSelectCountry={() => {}}
@@ -37,6 +40,7 @@ describe('components/FlagsMenu', () => {
   test('should list all countries without filters props', () => {
     render(
       <FlagsMenu
+        displayNames={getDisplayNames()}
         anchorEl={getAnchorEl()}
         isoCode="FR"
         onSelectCountry={() => {}}
@@ -51,6 +55,7 @@ describe('components/FlagsMenu', () => {
     })
     render(
       <FlagsMenu
+        displayNames={getDisplayNames()}
         anchorEl={getAnchorEl()}
         isoCode="FR"
         onSelectCountry={callback}
@@ -64,6 +69,7 @@ describe('components/FlagsMenu', () => {
   test('should list onlyCountries', () => {
     render(
       <FlagsMenu
+        displayNames={getDisplayNames()}
         anchorEl={getAnchorEl()}
         onlyCountries={['FR']}
         isoCode="FR"
@@ -78,6 +84,7 @@ describe('components/FlagsMenu', () => {
   test('should exclude countries', () => {
     render(
       <FlagsMenu
+        displayNames={getDisplayNames()}
         anchorEl={getAnchorEl()}
         excludedCountries={['FR']}
         isoCode="FR"
@@ -90,6 +97,7 @@ describe('components/FlagsMenu', () => {
   test('should display EU countries except FR', () => {
     render(
       <FlagsMenu
+        displayNames={getDisplayNames()}
         anchorEl={getAnchorEl()}
         excludedCountries={['FR']}
         continents={['EU']}
@@ -105,6 +113,7 @@ describe('components/FlagsMenu', () => {
   test('should display onlyCountries and not continents', () => {
     render(
       <FlagsMenu
+        displayNames={getDisplayNames()}
         anchorEl={getAnchorEl()}
         onlyCountries={['VE']}
         continents={['EU']}
@@ -119,6 +128,7 @@ describe('components/FlagsMenu', () => {
   test('should highlight preferred countries and in good order', () => {
     render(
       <FlagsMenu
+        displayNames={getDisplayNames()}
         anchorEl={getAnchorEl()}
         preferredCountries={['FR', 'BE', 'VE']}
         isoCode="FR"
@@ -134,6 +144,7 @@ describe('components/FlagsMenu', () => {
   test('should highlight preferred countries not excluded', () => {
     render(
       <FlagsMenu
+        displayNames={getDisplayNames()}
         anchorEl={getAnchorEl()}
         preferredCountries={['FR', 'BE', 'VE']}
         excludedCountries={['FR']}

--- a/src/components/FlagsMenu/FlagsMenu.tsx
+++ b/src/components/FlagsMenu/FlagsMenu.tsx
@@ -3,12 +3,10 @@ import FlagMenuItem from '@components/FlagMenuItem/FlagMenuItem'
 import Menu, { MenuProps } from '@mui/material/Menu'
 import type { MuiTelInputContinent } from '@shared/constants/continents'
 import { ISO_CODES, MuiTelInputCountry } from '@shared/constants/countries'
-import { DEFAULT_LANG } from '@shared/constants/lang'
 import {
   filterCountries,
   sortAlphabeticallyCountryCodes
 } from '@shared/helpers/country'
-import { getDisplayNames } from '@shared/helpers/intl'
 import { FlagSize } from '../../index.types'
 
 export type FlagsMenuProps = Partial<MenuProps> & {
@@ -16,7 +14,7 @@ export type FlagsMenuProps = Partial<MenuProps> & {
   onlyCountries?: MuiTelInputCountry[]
   excludedCountries?: MuiTelInputCountry[]
   preferredCountries?: MuiTelInputCountry[]
-  langOfCountryName?: string
+  displayNames: Intl.DisplayNames
   flagSize?: FlagSize
   continents?: MuiTelInputContinent[]
   onSelectCountry: (isoCode: MuiTelInputCountry) => void
@@ -28,18 +26,13 @@ const FlagsMenu = ({
   onSelectCountry,
   excludedCountries = [],
   onlyCountries = [],
-  langOfCountryName = DEFAULT_LANG,
+  displayNames,
   continents = [],
   preferredCountries = [],
   className,
   flagSize = 'small',
   ...rest
 }: FlagsMenuProps) => {
-  // Idem for the translations
-  const displayNames = React.useMemo(() => {
-    return getDisplayNames(langOfCountryName)
-  }, [langOfCountryName])
-
   const ISO_CODES_SORTED = sortAlphabeticallyCountryCodes(
     ISO_CODES,
     displayNames

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,6 +8,7 @@ import {
   getValidCountry
 } from '@shared/helpers/country'
 import { putCursorAtEndOfInput } from '@shared/helpers/dom'
+import { getDisplayNames } from '@shared/helpers/intl'
 import { assocRefToPropRef } from '@shared/helpers/ref'
 import { removeOccurrence } from '@shared/helpers/string'
 import { useMismatchProps } from '@shared/hooks/useMissmatchProps'
@@ -80,6 +81,10 @@ const MuiTelInput = React.forwardRef(
         disableFormatting,
         continents
       })
+
+    const displayNames = React.useMemo(() => {
+      return getDisplayNames(langOfCountryName)
+    }, [langOfCountryName])
 
     const handleOpenFlagsMenu = (
       event: React.MouseEvent<HTMLButtonElement, MouseEvent>
@@ -191,6 +196,7 @@ const MuiTelInput = React.forwardRef(
                   forceCallingCode={forceCallingCode}
                   onClick={handleOpenFlagsMenu}
                   disabled={disabled}
+                  countryName={isoCode ? displayNames.of(isoCode) : 'unknown'}
                   flagSize={flagSize}
                   disableDropdown={Boolean(disableDropdown)}
                 />
@@ -208,7 +214,7 @@ const MuiTelInput = React.forwardRef(
             isoCode={isoCode}
             preferredCountries={preferredCountries}
             onClose={handleCloseFlagsMenu}
-            langOfCountryName={langOfCountryName}
+            displayNames={displayNames}
             onSelectCountry={handleChangeCountry}
             flagSize={flagSize}
             {...MenuProps}


### PR DESCRIPTION
In the flag button. the aria label of the flag display as "unknown" even after selecting a country:
![image](https://github.com/viclafouch/mui-tel-input/assets/8109770/c8088521-4f0a-40f6-af27-aa9ff139c55f)

This pull request fixes this issue passing the right country name to be displayed on the flag aria. Additionally, reorganized the code to move the displayNames component one component before, ensuring the correct display of country names on `FlagsMenu` and `FlagButton`.

Please provide feedback or suggestions for improvements.