### PR TITLE
Update package json exports to include type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "exports": {
     ".": {
       "import": "./dist/mui-tel-input.es.js",
+      "types": "./dist/index.d.ts",
       "require": "./dist/mui-tel-input.umd.js"
     }
   },


### PR DESCRIPTION
Defines types in the exports map, so that imports work when leveraging the newer moduleResolution tsconfig values (nodenext, node16, bundler).

More info: https://github.com/microsoft/TypeScript/issues/52363

This is the error when using Vite.js + React + Typescript
![image](https://github.com/viclafouch/mui-tel-input/assets/16294504/61af37d3-4590-4abd-aee1-c0488ed8d050)
