### PR TITLE
fix: maintain cursor position after a change

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,7 +7,6 @@ import {
   getCallingCodeOfCountry,
   getValidCountry
 } from '@shared/helpers/country'
-import { putCursorAtEndOfInput } from '@shared/helpers/dom'
 import { assocRefToPropRef } from '@shared/helpers/ref'
 import { removeOccurrence } from '@shared/helpers/string'
 import { useMismatchProps } from '@shared/hooks/useMissmatchProps'
@@ -101,11 +100,6 @@ const MuiTelInput = React.forwardRef(
     const handleFocus = (
       event: React.FocusEvent<HTMLInputElement, Element>
     ): void => {
-      setTimeout(() => {
-        if (inputRef.current) {
-          putCursorAtEndOfInput(inputRef.current)
-        }
-      }, 0)
       onFocus?.(event)
     }
 

--- a/src/shared/hooks/usePhoneDigits.ts
+++ b/src/shared/hooks/usePhoneDigits.ts
@@ -158,6 +158,60 @@ export default function usePhoneDigits({
     return `+${getCallingCodeOfCountry(country)}${inputValue}`
   }
 
+  const setCursorPosition = (
+    event: React.ChangeEvent<HTMLInputElement>,
+    newValue: string,
+    prevValue: string,
+    cursorStart: number
+  ) => {
+    let cursor = event.target?.selectionStart || 0
+    const cursorCur = (event.target?.selectionStart || 0) + cursorStart
+
+    const previousValueLenActual = prevValue.replace(/\s/g, '').length
+
+    const newValueLen = newValue.length
+    const newValueLenAccActual = newValue.replace(/\s/g, '').length
+
+    const spacesPrevVal =
+      prevValue.substring(cursorStart, cursorCur).split(' ').length - 1
+    const spacesNewVal =
+      newValue.substring(cursorStart, cursorCur + 1).split(' ').length - 1
+
+    if (
+      newValueLenAccActual > previousValueLenActual &&
+      newValue[cursorCur - 1] === ' '
+    ) {
+      cursor += 1
+    } else if (
+      newValueLenAccActual > previousValueLenActual &&
+      spacesPrevVal > spacesNewVal
+    ) {
+      if (prevValue[cursor - 1] === ' ') {
+        cursor -= spacesPrevVal - spacesNewVal - 1
+      } else {
+        cursor -= spacesPrevVal - spacesNewVal
+      }
+    }
+    if (
+      newValueLenAccActual < previousValueLenActual &&
+      spacesNewVal > spacesPrevVal
+    ) {
+      if (newValue[cursor + 1] === ' ') {
+        cursor += spacesNewVal - spacesPrevVal + 1
+      } else {
+        cursor += spacesNewVal - spacesPrevVal
+      }
+    }
+
+    if (cursor > newValueLen) {
+      cursor = newValueLen
+    }
+
+    window.requestAnimationFrame(() => {
+      event.target.setSelectionRange(cursor, cursor)
+    })
+  }
+
   const onInputChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
     const inputValue = forceCallingCode
       ? makeSureStartWithPlusIsoCode(
@@ -177,6 +231,8 @@ export default function usePhoneDigits({
     const numberValue = asYouTypeRef.current.getNumberValue() || ''
 
     previousCountryRef.current = country
+
+    const previousValueStore = previousValue
 
     // Check if the country is excluded, or not part on onlyCountries, etc..
     if (numberValue && (!country || !matchIsIsoCodeValid(country))) {
@@ -206,6 +262,15 @@ export default function usePhoneDigits({
         isoCode: country,
         inputValue: formattedValue
       })
+    }
+    if (!disableFormatting) {
+      const countryCallingCodeLen =
+        buildOnChangeInfo('input').countryCallingCode?.length
+      const cursorStart =
+        forceCallingCode && countryCallingCodeLen
+          ? countryCallingCodeLen + 2
+          : 0
+      setCursorPosition(event, formattedValue, previousValueStore, cursorStart)
     }
   }
 


### PR DESCRIPTION
This pull request resolves two cursor positioning issues in the MUI Tel Input component:

- Prevents the cursor from jumping to the end of existing text when clicked. Users can now start editing from the clicked location.
- Maintains cursor position after making changes to the input.

Linked Issue: [#3](https://github.com/viclafouch/mui-tel-input/issues/5)
