### PR TITLE
Fix: package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "exports": {
     ".": {
       "import": "./dist/mui-tel-input.es.js",
+      "default": "./dist/mui-tel-input.es.js",
       "types": "./dist/index.d.ts"
     }
   },


### PR DESCRIPTION
"." object should contain "default". Without this, vite fails to resolve exports.

Since the package is module-only it should be marked as `"type": "module"` as well

![image](https://github.com/viclafouch/mui-tel-input/assets/47496309/bf84dae3-3c2e-464e-8377-55e5520d1b49)
![image](https://github.com/viclafouch/mui-tel-input/assets/47496309/dd6b0ddc-13a9-4345-b250-b28a99cf4018)
