### PR TITLE
Fix exports in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "exports": {
     ".": {
       "import": "./dist/mui-tel-input.es.js",
-      "default": "./dist/mui-tel-input.es.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/mui-tel-input.es.js"
     }
   },
   "repository": {


### PR DESCRIPTION
`"default"` should be the last key in `"exports"`, otherwise webpack throws errors compiling.