### PR TITLE
Allow override CDN location

### DIFF
--- a/docs/docs/api-reference.md
+++ b/docs/docs/api-reference.md
@@ -29,7 +29,7 @@ The callback gives you **2 parameters**:
   1. The new tel [value](#value) stringified
   2. An object of different useful informations about the tel (`country`, `extension`, etc..)
 
-Example:
+### Example
 
 ```tsx
 
@@ -56,7 +56,7 @@ const handleChange = (value, info) => {
 
 Sets the selected country on component mount
 
-Example:
+### Example
 
 ```tsx
 
@@ -70,6 +70,8 @@ Example:
 
 Displays the calling code (e.g: +33) as read-only next to the flag and with a divider instead of as part of the input field. Needs `defaultCountry` prop to be defined or will default to `US`.
 
+### Example
+
 ```tsx
 <MuiTelInput forceCallingCode />
 ```
@@ -80,6 +82,8 @@ Displays the calling code (e.g: +33) as read-only next to the flag and with a di
 - Default: `false`
 
 Autofocus the input when the user selects a country in the list.
+
+### Example
 
 ```tsx
 <MuiTelInput focusOnSelectCountry />
@@ -92,6 +96,8 @@ Autofocus the input when the user selects a country in the list.
 
 [Country codes](/docs/country-codes) to be included in the list of countries.
 
+### Example
+
 ```tsx
 <MuiTelInput onlyCountries={['FR', 'BE']} />
 ```
@@ -102,6 +108,8 @@ Autofocus the input when the user selects a country in the list.
 - Default: `undefined`
 
 [Country codes](/docs/country-codes) to be excluded of the list of countries.
+
+### Example
 
 ```tsx
 <MuiTelInput excludedCountries={['CA', 'PT']} />
@@ -114,6 +122,8 @@ Autofocus the input when the user selects a country in the list.
 
 [Country codes](/docs/country-codes) to be highlighted to the top of the list of countries.
 
+### Example
+
 ```tsx
 <MuiTelInput preferredCountries={['BE', 'FR']} />
 ```
@@ -124,6 +134,8 @@ Autofocus the input when the user selects a country in the list.
 - Default: `undefined`
 
 [Continent codes](/docs/continent-codes) to include a group of countries.
+
+### Example
 
 ```tsx
 <MuiTelInput continents={['EU', 'OC']} />
@@ -136,6 +148,8 @@ Autofocus the input when the user selects a country in the list.
 
 No country list / The current flag is a `span` instead of a `button`.
 
+### Example
+
 ```tsx
 <MuiTelInput disableDropdown />
 ```
@@ -146,6 +160,8 @@ No country list / The current flag is a `span` instead of a `button`.
 - Default: `false`
 
 Remove format (spaces..) from the input value.
+
+### Example
 
 ```tsx
 <MuiTelInput disableFormatting />
@@ -158,6 +174,8 @@ Remove format (spaces..) from the input value.
 
 An `Intl` locale to translate country names (see [Intl locales](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames/DisplayNames)). All countries will be translated in this language.
 
+### Example
+
 ```tsx
 <MuiTelInput langOfCountryName="fr" />
 ```
@@ -168,6 +186,8 @@ An `Intl` locale to translate country names (see [Intl locales](https://develope
 - Default: `small`
 
 The size corresponding to the flag component.
+
+### Example
 
 ```tsx
 <MuiTelInput flagSize="medium" />
@@ -180,6 +200,35 @@ The size corresponding to the flag component.
 
 Props for the MUI [Menu](https://mui.com/material-ui/api/menu/) component.
 
+### Example
+
 ```tsx
 <MuiTelInput MenuProps={{ disableAutoFocusItem: true }} />
+```
+
+## `getFlagSources`
+
+- Type: `GetFlagSources`
+- Default: `undefined`
+
+By default the flag icons are loaded from https://flagcdn.com, if you want to override this behavior you can do this via `getFlagSources`.
+
+You can provide the `FlagSource` object with a `srcSet` or a `src` attribute. With a `srcSet` it will be rendered as a `<source />` tag within a `<picture />`, with a `src` attribute it will be rendered as a regular image (`<img src=...`). Render a regular image could be usefull for example for a inline svg which is not allowed to be rendered in a `<picture />`.
+
+### Example
+
+```tsx
+const getFlagSources = (isoCode, size) => {
+  const isoCodeFormatted = isoCode ? isoCode.toLowerCase() : ''
+
+  return [
+    {
+      type: "image/png",
+      srcSet: `https://flagcdn.com/w${width}/${isoCodeFormatted}.png`,
+      width: size === "small" ? 40 : 80,
+    },
+  ]
+}
+
+<MuiTelInput getFlagSources={getFlagSources} />
 ```

--- a/src/components/Flag/Flag.tsx
+++ b/src/components/Flag/Flag.tsx
@@ -2,59 +2,86 @@ import React from 'react'
 import unknownFlag from '@assets/unknown-flag.png'
 import type { MuiTelInputCountry } from '@shared/constants/countries'
 import { FLAGS_SVG } from '@shared/constants/flags'
-import { FlagSize } from '../../index.types'
+import { FlagSize, GetFlagSources } from '../../index.types'
 import { Styled } from './Flag.styled'
 
 export type FlagProps = {
   isoCode: MuiTelInputCountry | null
   countryName?: string
   size?: FlagSize
+  getFlagSources?: GetFlagSources
 }
 
-const getSourceByIsoCode = (isoCode: MuiTelInputCountry | null) => {
+const getSourceByIsoCode = (
+  isoCode: MuiTelInputCountry | null,
+  width: number
+) => {
   if (!isoCode) {
-    return unknownFlag
+    return [{ src: unknownFlag, width }]
   }
 
   // Not exist on https://flagcdn.com
   if (isoCode === 'TA' || isoCode === 'AC') {
-    return {
-      TA: FLAGS_SVG.TA,
-      AC: FLAGS_SVG.AC
-    }[isoCode]
+    return [
+      {
+        width,
+        src: {
+          TA: FLAGS_SVG.TA,
+          AC: FLAGS_SVG.AC
+        }[isoCode]
+      }
+    ]
   }
 
-  return ''
+  return false
 }
 
-const Flag = ({ size = 'small', isoCode, countryName = '' }: FlagProps) => {
-  const isoCodeFormatted = isoCode ? isoCode.toLowerCase() : ''
-  const sourceFound = getSourceByIsoCode(isoCode)
+const defaultGetFlagSources: GetFlagSources = (isoCode, size) => {
   // see https://flagpedia.net/download/api for the valid width
   const width = size === 'small' ? 40 : 80
+  const isoCodeFormatted = isoCode ? isoCode.toLowerCase() : ''
+
+  return (
+    getSourceByIsoCode(isoCode, width) || [
+      {
+        type: 'image/png',
+        srcSet: `https://flagcdn.com/w${width}/${isoCodeFormatted}.png`,
+        width
+      },
+      {
+        type: 'image/webp',
+        srcSet: `https://flagcdn.com/w${width}/${isoCodeFormatted}.webp`,
+        width
+      }
+    ]
+  )
+}
+
+const Flag = ({
+  size = 'small',
+  isoCode,
+  countryName = '',
+  getFlagSources = defaultGetFlagSources
+}: FlagProps) => {
+  const sources = getFlagSources(isoCode, size)
+  const regularImage = sources.find(({ src }) => {
+    return src
+  })
+  const alt = countryName || 'unknown'
 
   return (
     <Styled.Flag data-testid={isoCode} className="MuiTelInput-Flag">
-      {sourceFound ? (
-        <img
-          src={sourceFound}
-          alt={countryName || 'unknown'}
-          width={width / 2}
-        />
+      {regularImage ? (
+        <img src={regularImage.src} width={regularImage.width / 2} alt={alt} />
       ) : (
         <Styled.Picture>
-          <source
-            type="image/webp"
-            srcSet={`https://flagcdn.com/w${width}/${isoCodeFormatted}.webp`}
-          />
-          <source
-            type="image/png"
-            srcSet={`https://flagcdn.com/w${width}/${isoCodeFormatted}.png`}
-          />
+          {sources.map(({ srcSet, type }) => {
+            return <source type={type} srcSet={srcSet} />
+          })}
           <img
-            src={`https://flagcdn.com/w${width}/${isoCodeFormatted}.png`}
-            width={width / 2}
-            alt={countryName || 'unknown'}
+            src={sources[0].srcSet}
+            width={sources[0].width / 2}
+            alt={alt}
             loading="lazy"
           />
         </Styled.Picture>

--- a/src/components/FlagMenuItem/FlagMenuItem.tsx
+++ b/src/components/FlagMenuItem/FlagMenuItem.tsx
@@ -3,7 +3,7 @@ import Flag from '@components/Flag/Flag'
 import { COUNTRIES, MuiTelInputCountry } from '@shared/constants/countries'
 import MenuItem, { MenuItemProps } from '@mui/material/MenuItem'
 import Typography from '@mui/material/Typography'
-import { FlagSize } from '../../index.types'
+import { FlagSize, GetFlagSources } from '../../index.types'
 import { Styled } from './FlagsMenuItem.styled'
 
 export type FlagMenuItemProps = MenuItemProps & {
@@ -11,6 +11,7 @@ export type FlagMenuItemProps = MenuItemProps & {
   onSelectCountry: (isoCode: MuiTelInputCountry) => void
   countryName: string | undefined
   flagSize?: FlagSize
+  getFlagSources?: GetFlagSources
 }
 
 const FlagMenuItem = ({
@@ -18,6 +19,7 @@ const FlagMenuItem = ({
   onSelectCountry,
   countryName,
   flagSize = 'small',
+  getFlagSources = undefined,
   ...menuItemProps
 }: FlagMenuItemProps) => {
   const handleClick = (event: React.MouseEvent<HTMLLIElement, MouseEvent>) => {
@@ -34,7 +36,12 @@ const FlagMenuItem = ({
       className="MuiTelInput-MenuItem"
     >
       <Styled.ListItemIcon className="MuiTelInput-ListItemIcon-flag">
-        <Flag size={flagSize} isoCode={isoCode} countryName={countryName} />
+        <Flag
+          size={flagSize}
+          isoCode={isoCode}
+          countryName={countryName}
+          getFlagSources={getFlagSources}
+        />
       </Styled.ListItemIcon>
       <Styled.ListItemText className="MuiTelInput-ListItemText-country">
         {countryName}

--- a/src/components/FlagsMenu/FlagsMenu.tsx
+++ b/src/components/FlagsMenu/FlagsMenu.tsx
@@ -9,7 +9,7 @@ import {
 } from '@shared/helpers/country'
 import { getDisplayNames } from '@shared/helpers/intl'
 import Menu, { MenuProps } from '@mui/material/Menu'
-import { FlagSize } from '../../index.types'
+import { FlagSize, GetFlagSources } from '../../index.types'
 
 export type FlagsMenuProps = Partial<MenuProps> & {
   isoCode: MuiTelInputCountry | null
@@ -20,6 +20,7 @@ export type FlagsMenuProps = Partial<MenuProps> & {
   flagSize?: FlagSize
   continents?: MuiTelInputContinent[]
   onSelectCountry: (isoCode: MuiTelInputCountry) => void
+  getFlagSources?: GetFlagSources
 }
 
 const defaultExcludedCountries: MuiTelInputCountry[] = []
@@ -38,6 +39,7 @@ const FlagsMenu = ({
   preferredCountries = defaultPreferredCountries,
   className,
   flagSize = 'small',
+  getFlagSources = undefined,
   ...rest
 }: FlagsMenuProps) => {
   // Idem for the translations
@@ -80,6 +82,7 @@ const FlagsMenu = ({
             selected={isoCodeItem === isoCode}
             id={`country-${isoCodeItem}`}
             flagSize={flagSize}
+            getFlagSources={getFlagSources}
           />
         )
       })}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -59,6 +59,7 @@ const MuiTelInput = React.forwardRef(
       MenuProps,
       className,
       flagSize = 'small',
+      getFlagSources,
       ...restTextFieldProps
     } = props
     const textFieldRef = React.useRef<HTMLDivElement>(null)
@@ -219,6 +220,7 @@ const MuiTelInput = React.forwardRef(
             langOfCountryName={langOfCountryName}
             onSelectCountry={handleChangeCountry}
             flagSize={flagSize}
+            getFlagSources={getFlagSources}
             {...MenuProps}
           />
         ) : null}

--- a/src/index.types.ts
+++ b/src/index.types.ts
@@ -15,6 +15,24 @@ export type FlagSize = `small` | 'medium'
 
 export type MuiTelInputReason = 'country' | 'input'
 
+type FlagSource =
+  | {
+      type: string
+      width: number
+      srcSet: string
+      src?: never
+    }
+  | {
+      type?: never
+      width: number
+      srcSet?: never
+      src: string
+    }
+export type GetFlagSources = (
+  isoCode: MuiTelInputCountry | null,
+  size: FlagSize
+) => FlagSource[]
+
 export interface MuiTelInputInfo {
   countryCode: MuiTelInputCountry | null
   countryCallingCode: string | null
@@ -40,4 +58,5 @@ export interface MuiTelInputProps extends BaseTextFieldProps {
   onChange?: (value: string, info: MuiTelInputInfo) => void
   value?: string | undefined
   MenuProps?: Partial<MenuProps>
+  getFlagSources?: GetFlagSources
 }


### PR DESCRIPTION
Possibility to override CDN location if you want to host the assets somewhere else.

Currently we're not able to use `mui-tel-input` because of a (very) strict CSP header which blocks the requests to flagcdn.com.