### PR TITLE
fix: correct input value concatenation on country change with disable…

### DIFF
--- a/src/shared/hooks/usePhoneDigits.ts
+++ b/src/shared/hooks/usePhoneDigits.ts
@@ -264,9 +264,18 @@ export default function usePhoneDigits({
 
     const callingCode = COUNTRIES[newCountry]?.[0] as string
     const { inputValue, isoCode } = state
-    const inputValueWithoutCallingCode = isoCode
-      ? removeOccurrence(inputValue, `+${getCallingCodeOfCountry(isoCode)}`)
-      : inputValue
+    let inputValueWithoutCallingCode = inputValue
+
+    if (isoCode) {
+      const callingCodeOfPreviousCountry = getCallingCodeOfCountry(isoCode)
+      // if the input value start with wrong calling code, set it to empty string
+      inputValueWithoutCallingCode = inputValue.startsWith(
+        `+${callingCodeOfPreviousCountry}`
+      )
+        ? removeOccurrence(inputValue, `+${callingCodeOfPreviousCountry}`)
+        : ''
+    }
+
     // replace the old calling code with the new one, keeping the rest of the number
     let newValue = `+${callingCode}${inputValueWithoutCallingCode}`
 


### PR DESCRIPTION
Fix for Issue #107: Incorrect Input Value on Country Change with disableFormatting

Hi Viclafouch, I've made an attempt to fix Issue #107 as i have also encountered this issue, where a bug was identified in the MuiTelInput component while using the disableFormatting prop. This issue caused the input value to incorrectly concatenate the calling codes upon changing the country.

Any thoughts you might want to run would be super helpful. I'm totally open to working together and tweaking things as needed to make sure this fix fits right in with the project. Also i will take a look for issue #106 