### PR TITLE
expose IconButtonProps for FlagButton

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -63,6 +63,7 @@ const MuiTelInput = React.forwardRef(
       continents,
       preferredCountries,
       MenuProps,
+      FlagButtonProps,
       className,
       getFlagElement = getDefaultFlagElement,
       unknownFlagElement = defaultUnknownFlagElement,
@@ -199,6 +200,7 @@ const MuiTelInput = React.forwardRef(
             startAdornment: (
               <InputAdornment position="start" sx={{ flexShrink: 0 }}>
                 <FlagButton
+                  {...FlagButtonProps}
                   isFlagsMenuOpened={Boolean(anchorEl)}
                   isoCode={isoCode}
                   forceCallingCode={forceCallingCode}

--- a/src/index.types.ts
+++ b/src/index.types.ts
@@ -1,6 +1,7 @@
 import { NumberType } from 'libphonenumber-js'
 import type { MuiTelInputContinent } from '@shared/constants/continents'
 import type { MuiTelInputCountry } from '@shared/constants/countries'
+import { IconButtonProps } from '@mui/material/IconButton'
 import type { MenuProps } from '@mui/material/Menu'
 import type { TextFieldProps } from '@mui/material/TextField'
 
@@ -60,6 +61,7 @@ export type MuiTelInputProps = BaseTextFieldProps &
     onChange?: (value: string, info: MuiTelInputInfo) => void
     value?: string | undefined
     MenuProps?: Partial<MenuProps>
+    FlagButtonProps?: Partial<IconButtonProps>
     getFlagElement?: GetFlagElement
     unknownFlagElement?: MuiTelInputFlagElement
   }


### PR DESCRIPTION
expose IconButtonProps for FlagButton to allow to customize some behavior/styling of the button via props. 
not sure if whole props are needed.
Example: to disable ripple effect on props level instead of adding some custom styling around the input