### PR TITLE
added commonJs module output

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,15 +7,17 @@
     "url": "https://github.com/viclafouch/mui-tel-input/issues"
   },
   "homepage": "https://viclafouch.github.io/mui-tel-input",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "files": [
     "dist"
   ],
-  "main": "./dist/mui-tel-input.es.js",
+  "main": "./dist/mui-tel-input.cjs.js",
+  "module": "./dist/mui-tel-input.es.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "import": "./dist/mui-tel-input.es.js",
+      "require": "./dist/mui-tel-input.cjs.js",
       "types": "./dist/index.d.ts",
       "default": "./dist/mui-tel-input.es.js"
     }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
     target: 'esnext',
     minify: true,
     lib: {
-      formats: ['es'],
+      formats: ['es', 'cjs'],
       entry: path.resolve(__dirname, 'src/index.tsx'),
       name: 'Mui-tel-input',
       fileName: format => `mui-tel-input.${format}.js`


### PR DESCRIPTION
added commonJs module output.

Context: we have ssr with express js and there common js modules are used, so at the moment server fails to work with current version of the lib from npm. think it may be usefull to distribute 2 kinds of modules as even mui have 2 version :) not sure if all changes are needed, maybe same thing could be done with less changes in package.json