### PR TITLE
docs: :memo: add Next.js integration instructions

### DIFF
--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -15,6 +15,24 @@ yarn add mui-tel-input
 
 We have completed installing the package.
 
+## Next.js integration
+
+Learn how to use MUI tel input with Next.js
+
+Once you have installed MUI tel input in your next.js project, it is important to transpile this package so that it is compatible with the project, both in development and production.
+
+```js
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+ transpilePackages: [
+   'mui-tel-input',
+ ],
+ // your config
+}
+
+module.exports = nextConfig
+```
+
 ## Simple usage
 
 Here is a simple usage for using the component:


### PR DESCRIPTION
## Description
Add Next.js integration instructions

## Why
When I install the first time, my next.js project has a transpile error when importing, looking for the solution I found that by adding in your config file next.js transpilePackages, the problem has solution.

For people who want to use this library in their next.js projects, it is recommended to use this configuration to avoid the transpile error problem.