### PR TITLE
Expose flagImage className

### DIFF
--- a/docs/docs/css.md
+++ b/docs/docs/css.md
@@ -18,7 +18,7 @@ Classes are also abstracted and exported as `classes`, to keep a stable interfac
 | `.MuiTelInput-TextField`               | `classes.textField`         | 	Styles applied to the root element.                                                                   |
 | `.MuiTelInput-IconButton`              | `classes.flagButton`        | 	Styles applied to the [IconButton](https://mui.com/material-ui/api/icon-button/) of the current flag. |
 | `.MuiTelInput-Flag`                    | `classes.flagContainer`     | 	Styles applied to the element around the image of a flag.                                             |
-| `.MuiTelInput-Flag-Image`              | `classes.flagImg`           | 	Styles applied to the image within a flag element.                                                    |
+| `.MuiTelInput-FlagImg`              | `classes.flagImg`           | 	Styles applied to the image within a flag element.                                                    |
 | `.MuiTelInput-Menu`                    | `classes.menu`              | 	Styles applied to [Menu](https://mui.com/material-ui/api/menu/) component.                            |
 | `.MuiTelInput-MenuItem`                | `classes.menuItem`          | 	Styles applied to a flag item of the [Menu](https://mui.com/material-ui/api/menu/).                   |
 | `.MuiTelInput-ListItemIcon-flag`       | `classes.listItemIconFlag`  | 	Styles applied to the [ListItemIcon](https://mui.com/material-ui/api/list-item-icon/) of a flag item  |

--- a/docs/docs/css.md
+++ b/docs/docs/css.md
@@ -13,17 +13,17 @@ Like any component, if you want to override a component's styles using custom cl
 Then, you can use the differents global class names (see below) to target an element of `MuiTelInput`.
 Classes are also abstracted and exported as `classes`, to keep a stable interface for consumers.
 
-| 	Global class                          | exported constant             | Description                                                                                            |
-|----------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------|
-| `.MuiTelInput-TextField`               | `classes.textField`           | 	Styles applied to the root element.                                                                   |
-| `.MuiTelInput-IconButton`              | `classes.flagButton`          | 	Styles applied to the [IconButton](https://mui.com/material-ui/api/icon-button/) of the current flag. |
-| `.MuiTelInput-Flag`                    | `classes.flagContainer`       | 	Styles applied to the element around the image of a flag.                                             |
-| `.MuiTelInput-Flag-Image`              | `classes.flagImage`           | 	Styles applied to the image within a flag element.                                                    |
-| `.MuiTelInput-Menu`                    | `classes.menu`                | 	Styles applied to [Menu](https://mui.com/material-ui/api/menu/) component.                            |
-| `.MuiTelInput-MenuItem`                | `classes.menuItem`            | 	Styles applied to a flag item of the [Menu](https://mui.com/material-ui/api/menu/).                   |
-| `.MuiTelInput-ListItemIcon-flag`       | `classes.listItemIconFlag`    | 	Styles applied to the [ListItemIcon](https://mui.com/material-ui/api/list-item-icon/) of a flag item  |
+| 	Global class                          | exported constant           | Description                                                                                            |
+|----------------------------------------|-----------------------------|--------------------------------------------------------------------------------------------------------|
+| `.MuiTelInput-TextField`               | `classes.textField`         | 	Styles applied to the root element.                                                                   |
+| `.MuiTelInput-IconButton`              | `classes.flagButton`        | 	Styles applied to the [IconButton](https://mui.com/material-ui/api/icon-button/) of the current flag. |
+| `.MuiTelInput-Flag`                    | `classes.flagContainer`     | 	Styles applied to the element around the image of a flag.                                             |
+| `.MuiTelInput-Flag-Image`              | `classes.flagImg`           | 	Styles applied to the image within a flag element.                                                    |
+| `.MuiTelInput-Menu`                    | `classes.menu`              | 	Styles applied to [Menu](https://mui.com/material-ui/api/menu/) component.                            |
+| `.MuiTelInput-MenuItem`                | `classes.menuItem`          | 	Styles applied to a flag item of the [Menu](https://mui.com/material-ui/api/menu/).                   |
+| `.MuiTelInput-ListItemIcon-flag`       | `classes.listItemIconFlag`  | 	Styles applied to the [ListItemIcon](https://mui.com/material-ui/api/list-item-icon/) of a flag item  |
 | `.MuiTelInput-ListItemText-country`    | `classes.listItemTextCountry` | 	Styles applied to the [ListItemText](https://mui.com/material-ui/api/list-item-text/) of a flag item  |
-| `.MuiTelInput-Typography-calling-code` | `classes.callingCode`         | 	Styles applied to the calling code of a flag item                                                     |
+| `.MuiTelInput-Typography-calling-code` | `classes.callingCode`       | 	Styles applied to the calling code of a flag item                                                     |
 
 For example: target the `.MuiTelInput-Flag` global class name to customize the current selected flag.
 

--- a/docs/docs/css.md
+++ b/docs/docs/css.md
@@ -13,16 +13,17 @@ Like any component, if you want to override a component's styles using custom cl
 Then, you can use the differents global class names (see below) to target an element of `MuiTelInput`.
 Classes are also abstracted and exported as `classes`, to keep a stable interface for consumers.
 
-| 	Global class       | exported constant          | Description                                                                                                                   |
-| ---------------------|----------------------------| ----------------------------------------------------------------------------------------------------------------------------- |
-| `.MuiTelInput-TextField`      | `classes.textField`                          | 	Styles applied to the root element.                                                                                                                   |
-| `.MuiTelInput-IconButton`    | `classes.flagButton`                            | 	Styles applied to the [IconButton](https://mui.com/material-ui/api/icon-button/) of the current flag.                                                                                                                   |
-| `.MuiTelInput-Flag`    | `classes.flag`                                  | 	Styles applied to a flag.                                                                                                                   |
-| `.MuiTelInput-Menu`    | `classes.menu`                                  | 	Styles applied to [Menu](https://mui.com/material-ui/api/menu/) component.                                                                                                                   |
-| `.MuiTelInput-MenuItem`   | `classes.menuItem`                               | 	Styles applied to a flag item of the [Menu](https://mui.com/material-ui/api/menu/).                                                                                                                   |
-| `.MuiTelInput-ListItemIcon-flag`      | `classes.listItemIconFlag`                     | 	Styles applied to the [ListItemIcon](https://mui.com/material-ui/api/list-item-icon/) of a flag item                                                                                                                   |
-| `.MuiTelInput-ListItemText-country`    | `classes.listItemTextCountry`                             | 	Styles applied to the [ListItemText](https://mui.com/material-ui/api/list-item-text/) of a flag item                                                                                                                   |
-| `.MuiTelInput-Typography-calling-code`   | `classes.callingCode`                               | 	Styles applied to the calling code of a flag item                                                                                                                  |
+| 	Global class                          | exported constant             | Description                                                                                            |
+|----------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------|
+| `.MuiTelInput-TextField`               | `classes.textField`           | 	Styles applied to the root element.                                                                   |
+| `.MuiTelInput-IconButton`              | `classes.flagButton`          | 	Styles applied to the [IconButton](https://mui.com/material-ui/api/icon-button/) of the current flag. |
+| `.MuiTelInput-Flag`                    | `classes.flagContainer`       | 	Styles applied to the element around the image of a flag.                                             |
+| `.MuiTelInput-Flag-Image`              | `classes.flagImage`           | 	Styles applied to the image within a flag element.                                                    |
+| `.MuiTelInput-Menu`                    | `classes.menu`                | 	Styles applied to [Menu](https://mui.com/material-ui/api/menu/) component.                            |
+| `.MuiTelInput-MenuItem`                | `classes.menuItem`            | 	Styles applied to a flag item of the [Menu](https://mui.com/material-ui/api/menu/).                   |
+| `.MuiTelInput-ListItemIcon-flag`       | `classes.listItemIconFlag`    | 	Styles applied to the [ListItemIcon](https://mui.com/material-ui/api/list-item-icon/) of a flag item  |
+| `.MuiTelInput-ListItemText-country`    | `classes.listItemTextCountry` | 	Styles applied to the [ListItemText](https://mui.com/material-ui/api/list-item-text/) of a flag item  |
+| `.MuiTelInput-Typography-calling-code` | `classes.callingCode`         | 	Styles applied to the calling code of a flag item                                                     |
 
 For example: target the `.MuiTelInput-Flag` global class name to customize the current selected flag.
 

--- a/src/components/Flag/Flag.tsx
+++ b/src/components/Flag/Flag.tsx
@@ -7,11 +7,11 @@ export type FlagProps = {
   children: React.ReactNode
 }
 
-export const flagClass = 'MuiTelInput-Flag'
+export const flagContainerClass = 'MuiTelInput-Flag'
 
 const Flag = ({ isoCode, children }: FlagProps) => {
   return (
-    <Styled.Flag data-testid={isoCode} className={flagClass}>
+    <Styled.Flag data-testid={isoCode} className={flagContainerClass}>
       {children}
     </Styled.Flag>
   )

--- a/src/index.stories.tsx
+++ b/src/index.stories.tsx
@@ -72,7 +72,7 @@ export const Primary: StoryFn<typeof MuiTelInput> = (args) => {
 }
 
 const WithStyledFlag = styled(MuiTelInput)`
-  .${classes.flag} > img {
+  .${classes.flagImage} {
     filter: grayscale(100%);
     width: 20px;
   }
@@ -95,7 +95,7 @@ export const CustomizationByClassNameConstant: StoryFn<typeof MuiTelInput> = (
     <Box>
       <pre>
         <code>{`const WithStyledFlag = styled(MuiTelInput)
-  .\${classes.flag} > img {
+  .\${classes.flagImage} {
     filter: grayscale(100%);
     width: 20px;
   }

--- a/src/index.stories.tsx
+++ b/src/index.stories.tsx
@@ -72,7 +72,7 @@ export const Primary: StoryFn<typeof MuiTelInput> = (args) => {
 }
 
 const WithStyledFlag = styled(MuiTelInput)`
-  .${classes.flagImage} {
+  .${classes.flagImg} {
     filter: grayscale(100%);
     width: 20px;
   }
@@ -95,7 +95,7 @@ export const CustomizationByClassNameConstant: StoryFn<typeof MuiTelInput> = (
     <Box>
       <pre>
         <code>{`const WithStyledFlag = styled(MuiTelInput)
-  .\${classes.flagImage} {
+  .\${classes.flagImg} {
     filter: grayscale(100%);
     width: 20px;
   }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -245,7 +245,7 @@ const MuiTelInput = React.forwardRef(
 export const classes = {
   textField: textFieldClass,
   flagContainer: flagContainerClass,
-  flagImage: flagImageClass,
+  flagImg: flagImageClass,
   flagButton: flagButtonClass,
   menu: menuClass,
   menuItem: menuItemClass,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { flagClass } from '@components/Flag/Flag'
+import { flagContainerClass } from '@components/Flag/Flag'
 import FlagButton, { flagButtonClass } from '@components/FlagButton/FlagButton'
 import {
   callingCodeClass,
@@ -15,6 +15,7 @@ import {
 import { putCursorAtEndOfInput } from '@shared/helpers/dom'
 import {
   defaultUnknownFlagElement,
+  flagImageClass,
   getDefaultFlagElement
 } from '@shared/helpers/flag'
 import { assocRefToPropRef } from '@shared/helpers/ref'
@@ -243,7 +244,8 @@ const MuiTelInput = React.forwardRef(
 
 export const classes = {
   textField: textFieldClass,
-  flag: flagClass,
+  flagContainer: flagContainerClass,
+  flagImage: flagImageClass,
   flagButton: flagButtonClass,
   menu: menuClass,
   menuItem: menuItemClass,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,7 +15,7 @@ import {
 import { putCursorAtEndOfInput } from '@shared/helpers/dom'
 import {
   defaultUnknownFlagElement,
-  flagImageClass,
+  flagImgClass,
   getDefaultFlagElement
 } from '@shared/helpers/flag'
 import { assocRefToPropRef } from '@shared/helpers/ref'
@@ -245,7 +245,7 @@ const MuiTelInput = React.forwardRef(
 export const classes = {
   textField: textFieldClass,
   flagContainer: flagContainerClass,
-  flagImg: flagImageClass,
+  flagImg: flagImgClass,
   flagButton: flagButtonClass,
   menu: menuClass,
   menuItem: menuItemClass,

--- a/src/shared/helpers/flag.tsx
+++ b/src/shared/helpers/flag.tsx
@@ -16,7 +16,7 @@ const getDefaultImageSrc = (isoCode: MuiTelInputCountry) => {
   return `https://flagcdn.com/w40/${isoCode.toLowerCase()}.webp`
 }
 
-export const flagImgClass = 'MuiTelInput-Flag-Image'
+export const flagImgClass = 'MuiTelInput-FlagImg'
 
 export const getDefaultImgProps = ({
   isoCode,

--- a/src/shared/helpers/flag.tsx
+++ b/src/shared/helpers/flag.tsx
@@ -16,6 +16,8 @@ const getDefaultImageSrc = (isoCode: MuiTelInputCountry) => {
   return `https://flagcdn.com/w40/${isoCode.toLowerCase()}.webp`
 }
 
+export const flagImageClass = 'MuiTelInput-Flag-Image'
+
 export const getDefaultImgProps = ({
   isoCode,
   countryName
@@ -27,7 +29,8 @@ export const getDefaultImgProps = ({
     src: getDefaultImageSrc(isoCode),
     loading: 'lazy',
     width: 26,
-    alt: countryName
+    alt: countryName,
+    className: flagImageClass
   } satisfies React.ComponentPropsWithoutRef<'img'>
 }
 
@@ -41,5 +44,11 @@ export const getDefaultFlagElement: GetFlagElement = (
 }
 
 export const defaultUnknownFlagElement = (
-  <img src={unknownFlag} loading="lazy" width={26} alt="unknown" />
+  <img
+    src={unknownFlag}
+    loading="lazy"
+    width={26}
+    alt="unknown"
+    className={flagImageClass}
+  />
 )

--- a/src/shared/helpers/flag.tsx
+++ b/src/shared/helpers/flag.tsx
@@ -16,7 +16,7 @@ const getDefaultImageSrc = (isoCode: MuiTelInputCountry) => {
   return `https://flagcdn.com/w40/${isoCode.toLowerCase()}.webp`
 }
 
-export const flagImageClass = 'MuiTelInput-Flag-Image'
+export const flagImgClass = 'MuiTelInput-Flag-Image'
 
 export const getDefaultImgProps = ({
   isoCode,
@@ -30,7 +30,7 @@ export const getDefaultImgProps = ({
     loading: 'lazy',
     width: 26,
     alt: countryName,
-    className: flagImageClass
+    className: flagImgClass
   } satisfies React.ComponentPropsWithoutRef<'img'>
 }
 
@@ -49,6 +49,6 @@ export const defaultUnknownFlagElement = (
     loading="lazy"
     width={26}
     alt="unknown"
-    className={flagImageClass}
+    className={flagImgClass}
   />
 )


### PR DESCRIPTION
Adds to https://github.com/viclafouch/mui-tel-input/pull/128. Now consumers don't have to select the image within the flag using potentially unsafe selectors (that might break over time) but can use a constant. Sharpens namings on exposed classes: `classes.flag` becomes `flagContainer`, to express that the `span` around the `img` is targeted

| BEFORE | AFTER |
|--------|--------|
|<img width="1038" alt="image" src="https://github.com/viclafouch/mui-tel-input/assets/107466292/b49e4022-f635-4d99-841a-e29c1243d0ca"> |<img width="657" alt="image" src="https://github.com/viclafouch/mui-tel-input/assets/107466292/e6ba31c2-3379-4a2b-97fc-653169133477"> | 

