### PR TITLE
Fix countries sort by display name

### DIFF
--- a/src/components/FlagsMenu/FlagsMenu.tsx
+++ b/src/components/FlagsMenu/FlagsMenu.tsx
@@ -3,10 +3,7 @@ import FlagMenuItem from '@components/FlagMenuItem/FlagMenuItem'
 import type { MuiTelInputContinent } from '@shared/constants/continents'
 import { ISO_CODES, MuiTelInputCountry } from '@shared/constants/countries'
 import { DEFAULT_LANG } from '@shared/constants/lang'
-import {
-  filterCountries,
-  sortAlphabeticallyCountryCodes
-} from '@shared/helpers/country'
+import { filterCountries } from '@shared/helpers/country'
 import { getDisplayNames } from '@shared/helpers/intl'
 import Menu, { MenuProps } from '@mui/material/Menu'
 import type { GetFlagElement } from '../../index.types'
@@ -46,12 +43,7 @@ const FlagsMenu = ({
     return getDisplayNames(langOfCountryName)
   }, [langOfCountryName])
 
-  const ISO_CODES_SORTED = sortAlphabeticallyCountryCodes(
-    ISO_CODES,
-    displayNames
-  )
-
-  const countriesFiltered = filterCountries(ISO_CODES_SORTED, {
+  const countriesFiltered = filterCountries(ISO_CODES, displayNames, {
     onlyCountries,
     excludedCountries,
     continents,

--- a/src/shared/helpers/__tests__/country.test.ts
+++ b/src/shared/helpers/__tests__/country.test.ts
@@ -1,37 +1,44 @@
 import { expect } from 'vitest'
 import { MuiTelInputCountry } from '@shared/constants/countries'
+import { DEFAULT_LANG } from '@shared/constants/lang'
 import { filterCountries, sortAlphabeticallyCountryCodes } from '../country'
+import { getDisplayNames } from '../intl'
 
-const COUNTRIES: readonly MuiTelInputCountry[] = ['FR', 'BE', 'US', 'VE']
+const COUNTRIES: readonly MuiTelInputCountry[] = ['BE', 'FR', 'US', 'VE']
+const COUNTRIES_DISPLAY_NAME = getDisplayNames(DEFAULT_LANG)
 
 describe('helpers/country', () => {
   describe('filterCountries', () => {
     it('should return an array', () => {
-      expect(filterCountries(COUNTRIES, {})).toBeInstanceOf(Array)
+      expect(
+        filterCountries(COUNTRIES, COUNTRIES_DISPLAY_NAME, {})
+      ).toBeInstanceOf(Array)
     })
     it('should return the exact same array when no filters options', () => {
-      expect(filterCountries(COUNTRIES, {})).toBe(COUNTRIES)
+      expect(
+        filterCountries(COUNTRIES, COUNTRIES_DISPLAY_NAME, {})
+      ).toStrictEqual(COUNTRIES)
     })
 
     it('should return the exact same array when filters options are empty', () => {
       expect(
-        filterCountries(COUNTRIES, {
+        filterCountries(COUNTRIES, COUNTRIES_DISPLAY_NAME, {
           onlyCountries: [],
           excludedCountries: []
         })
-      ).toBe(COUNTRIES)
+      ).toStrictEqual(COUNTRIES)
     })
 
     it('should remove FR when exclude FR', () => {
       expect(
-        filterCountries(COUNTRIES, {
+        filterCountries(COUNTRIES, COUNTRIES_DISPLAY_NAME, {
           excludedCountries: ['FR']
         })
       ).toEqual(['BE', 'US', 'VE'])
     })
     it('should only contain FR when only FR', () => {
       expect(
-        filterCountries(COUNTRIES, {
+        filterCountries(COUNTRIES, COUNTRIES_DISPLAY_NAME, {
           onlyCountries: ['FR']
         })
       ).toEqual(['FR'])
@@ -39,7 +46,7 @@ describe('helpers/country', () => {
 
     it('should only contain BE when onlyCountries is BE and even exclude BE', () => {
       expect(
-        filterCountries(COUNTRIES, {
+        filterCountries(COUNTRIES, COUNTRIES_DISPLAY_NAME, {
           onlyCountries: ['BE'],
           excludedCountries: ['BE']
         })
@@ -48,7 +55,7 @@ describe('helpers/country', () => {
 
     it('should only contain EU and SA countries', () => {
       expect(
-        filterCountries(COUNTRIES, {
+        filterCountries(COUNTRIES, COUNTRIES_DISPLAY_NAME, {
           continents: ['EU', 'SA']
         }).length
       ).toBe(67)
@@ -56,7 +63,7 @@ describe('helpers/country', () => {
 
     it('should only contain EU and SA countries except excluded countries', () => {
       expect(
-        filterCountries(COUNTRIES, {
+        filterCountries(COUNTRIES, COUNTRIES_DISPLAY_NAME, {
           continents: ['EU', 'SA'],
           excludedCountries: ['BE', 'FR', 'VE']
         }).length
@@ -65,11 +72,11 @@ describe('helpers/country', () => {
 
     it('should only contain onlyCountries even with continents filled', () => {
       expect(
-        filterCountries(COUNTRIES, {
+        filterCountries(COUNTRIES, COUNTRIES_DISPLAY_NAME, {
           continents: ['EU', 'SA'],
           onlyCountries: ['BE', 'FR', 'VE']
         })
-      ).toEqual(['FR', 'BE', 'VE'])
+      ).toEqual(['BE', 'FR', 'VE'])
     })
   })
 

--- a/src/shared/helpers/country.ts
+++ b/src/shared/helpers/country.ts
@@ -23,7 +23,7 @@ export function getValidCountry(
   return country || DEFAULT_ISO_CODE
 }
 
-export function sortedPreferredCountries(
+export function sortPreferredCountries(
   countries: readonly MuiTelInputCountry[],
   preferredCountries: readonly MuiTelInputCountry[]
 ): readonly MuiTelInputCountry[] {
@@ -60,43 +60,6 @@ export function excludeCountries(
   return countries
 }
 
-export function filterCountries(
-  countries: readonly MuiTelInputCountry[],
-  options: FilterCountriesOptions
-): readonly MuiTelInputCountry[] {
-  const { onlyCountries, excludedCountries, continents, preferredCountries } =
-    options
-
-  if (matchIsArray(onlyCountries, true)) {
-    const filteredCountries = getOnlyCountries(countries, onlyCountries)
-
-    return matchIsArray(preferredCountries, true)
-      ? sortedPreferredCountries(filteredCountries, preferredCountries)
-      : filteredCountries
-  }
-
-  const theCountries = matchIsArray(continents, true)
-    ? getCountriesOfContinents(continents)
-    : countries
-
-  const sortedCountries = matchIsArray(preferredCountries, true)
-    ? sortedPreferredCountries(theCountries, preferredCountries)
-    : theCountries
-
-  return matchIsArray(excludedCountries, true)
-    ? excludeCountries(sortedCountries, excludedCountries)
-    : sortedCountries
-}
-
-export function matchContinentsIncludeCountry(
-  continents: MuiTelInputContinent[],
-  isoCode: MuiTelInputCountry
-) {
-  return continents.some((continentCode) => {
-    return CONTINENTS[continentCode].includes(isoCode)
-  })
-}
-
 export function sortAlphabeticallyCountryCodes(
   countryCodes: readonly MuiTelInputCountry[],
   displayNames: Intl.DisplayNames
@@ -106,5 +69,51 @@ export function sortAlphabeticallyCountryCodes(
     const countryB = displayNames.of(countryCodeB) as string
 
     return countryA.localeCompare(countryB)
+  })
+}
+
+export function filterCountries(
+  countries: readonly MuiTelInputCountry[],
+  displayNames: Intl.DisplayNames,
+  options: FilterCountriesOptions
+): readonly MuiTelInputCountry[] {
+  const { onlyCountries, excludedCountries, continents, preferredCountries } =
+    options
+
+  if (matchIsArray(onlyCountries, true)) {
+    const filteredCountries = sortAlphabeticallyCountryCodes(
+      getOnlyCountries(countries, onlyCountries),
+      displayNames
+    )
+
+    return matchIsArray(preferredCountries, true)
+      ? sortPreferredCountries(filteredCountries, preferredCountries)
+      : filteredCountries
+  }
+
+  const theCountries = matchIsArray(continents, true)
+    ? getCountriesOfContinents(continents)
+    : countries
+
+  const sortedCountries = sortAlphabeticallyCountryCodes(
+    theCountries,
+    displayNames
+  )
+
+  const sortedPreferredCountries = matchIsArray(preferredCountries, true)
+    ? sortPreferredCountries(sortedCountries, preferredCountries)
+    : sortedCountries
+
+  return matchIsArray(excludedCountries, true)
+    ? excludeCountries(sortedPreferredCountries, excludedCountries)
+    : sortedPreferredCountries
+}
+
+export function matchContinentsIncludeCountry(
+  continents: MuiTelInputContinent[],
+  isoCode: MuiTelInputCountry
+) {
+  return continents.some((continentCode) => {
+    return CONTINENTS[continentCode].includes(isoCode)
   })
 }


### PR DESCRIPTION
When specifying an array in the `continents` prop, such as `['EU']`, the countries in the flag menu do not sort correctly by display name. This occurs when passing props that influence the displayed country list:
![image](https://github.com/viclafouch/mui-tel-input/assets/162106405/20ea87dd-dcb7-480d-9775-fd5095c6869a)

This PR addresses and resolves this sorting issue.

Have a nice day.
