### PR TITLE
fix: allow country change on input with forceCallingCode enabled

### DIFF
--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -178,24 +178,6 @@ describe('components/MuiTelInput', () => {
       expect(getInputElement().value).toBe('')
     })
 
-    test('should not accept the + at the beginning', async () => {
-      render(<MuiTelWrapper defaultCountry="FR" forceCallingCode />)
-      await typeInInputElement('+33626')
-      expect(getInputElement().value).toBe('3 36 26')
-      expectButtonIsFlagOf('FR')
-      expectButtonContainsCallingCode('33')
-    })
-
-    test('should not change country even if same country code', async () => {
-      // JM and US have the same country code, +1
-      render(<MuiTelWrapper forceCallingCode defaultCountry="US" />)
-      expectButtonIsFlagOf('US')
-      expectButtonContainsCallingCode('1')
-      await typeInInputElement('87654')
-      expectButtonIsFlagOf('US')
-      expectButtonContainsCallingCode('1')
-    })
-
     test('should give same value on the onChange callback', async () => {
       const callbackOnChange = vi.fn(() => {})
 
@@ -241,6 +223,40 @@ describe('components/MuiTelInput', () => {
       expectButtonIsFlagOf('BE')
       expectButtonContainsCallingCode('32')
       expect(getInputElement().value).toBe('72 1')
+    })
+
+    test('should remove the country code on paste', async () => {
+      render(<MuiTelWrapper defaultCountry="FI" forceCallingCode />)
+      await userEvent.click(getInputElement())
+      await userEvent.paste('+358 40 123456')
+      expect(getInputElement().value).toBe('40 123456')
+      expectButtonIsFlagOf('FI')
+      expectButtonContainsCallingCode('358')
+    })
+
+    test('should remove the country code on input', async () => {
+      render(<MuiTelWrapper defaultCountry="FI" forceCallingCode />)
+      await typeInInputElement('+358 40 123456')
+      expect(getInputElement().value).toBe('40 123456')
+      expectButtonIsFlagOf('FI')
+      expectButtonContainsCallingCode('358')
+    })
+
+    test('should remove the country code on paste, non-default country', async () => {
+      render(<MuiTelWrapper defaultCountry="SE" forceCallingCode />)
+      await userEvent.click(getInputElement())
+      await userEvent.paste('+358 40 123456')
+      expect(getInputElement().value).toBe('40 123456')
+      expectButtonIsFlagOf('FI')
+      expectButtonContainsCallingCode('358')
+    })
+
+    test('should remove the country code on input, non-default country', async () => {
+      render(<MuiTelWrapper defaultCountry="SE" forceCallingCode />)
+      await typeInInputElement('+358 40 123456')
+      expect(getInputElement().value).toBe('40 123456')
+      expectButtonIsFlagOf('FI')
+      expectButtonContainsCallingCode('358')
     })
   })
 

--- a/src/shared/hooks/usePhoneDigits.ts
+++ b/src/shared/hooks/usePhoneDigits.ts
@@ -160,7 +160,9 @@ export default function usePhoneDigits({
     inputValue: string,
     country: MuiTelInputCountry
   ): string => {
-    return `+${getCallingCodeOfCountry(country)}${inputValue}`
+    return inputValue.startsWith('+') || inputValue === ''
+      ? inputValue
+      : `+${getCallingCodeOfCountry(country)}${inputValue}`
   }
 
   const onInputChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
@@ -174,10 +176,11 @@ export default function usePhoneDigits({
     // formatted : e.g: +33 6 26 92..
     const formattedValue = typeNewValue(inputValue)
     const newCountryCode = asYouTypeRef.current.getCountry()
-    const country = forceCallingCode
-      ? // always the same country, can't change
-        (state.isoCode as MuiTelInputCountry)
-      : newCountryCode || previousCountryRef.current
+    const country =
+      newCountryCode ||
+      (forceCallingCode
+        ? (state.isoCode as MuiTelInputCountry)
+        : previousCountryRef.current)
     // Not formatted : e.g: +336269226..
     const numberValue = asYouTypeRef.current.getNumberValue() || ''
 


### PR DESCRIPTION
closes #139 
closes #58 

Allow autofill / paste to work on the input while forceCallingCode option is enabled.
