### PR TITLE
fix: typo in phone validation docs

### DIFF
--- a/docs/docs/phone-validation.md
+++ b/docs/docs/phone-validation.md
@@ -15,8 +15,8 @@ const MyComponent = () => {
 
   const handleChange = (newValue) => {
     matchIsValidTel(newValue, {
-      onlyCountryies: [], // optional,
-      excludedCountryies: [], // optional
+      onlyCountries: [], // optional,
+      excludedCountries: [], // optional
       continents: [] // optional
     }) // true | false
   }


### PR DESCRIPTION
### 🩹 Fixes

Corrected typos in the excludedCountries and onlyCountries keys in phone validation documentation.