### PR TITLE
Fix: Dialling Code Dropdown appears below Helper Text

### DIFF
--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -465,6 +465,19 @@ describe('components/MuiTelInput', () => {
       await closeFlagsMenu()
       expect(screen.queryByRole('presentation')).toBeFalsy()
     })
+
+    test('should anchor to input element ignoring helper text', async () => {
+      const screen = render(<MuiTelWrapper helperText="helpertext" onlyCountries={['US', 'GB']} />);
+      const inputElement = getInputElement()
+      fireEvent.click(getButtonElement())
+
+      const inputRect = inputElement.getBoundingClientRect();
+      const menuRect = screen.getByRole('presentation').getBoundingClientRect();
+      const helperRect = screen.getByText('helpertext').getBoundingClientRect();
+
+      expect(menuRect.top).toBeGreaterThanOrEqual(inputRect.bottom);
+      expect(menuRect.bottom).toBeLessThanOrEqual(helperRect.top);
+    });
   })
 
   test('should display in correct format FR number', async () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -141,7 +141,7 @@ const MuiTelInput = (props: MuiTelInputProps) => {
         type="tel"
         disabled={disabled}
         value={validInputValue}
-        ref={refToRefs([propRef, anchorRef])}
+        ref={refToRefs([propRef])}
         onDoubleClick={handleDoubleClick}
         inputRef={refToRefs([inputRef, inputRefFromProps])}
         className={`${textFieldClass} ${className || ''}`}
@@ -170,6 +170,7 @@ const MuiTelInput = (props: MuiTelInputProps) => {
                 />
               </InputAdornment>
             ),
+            ref: anchorRef,
             // eslint-disable-next-line @typescript-eslint/no-misused-spread
             ...slotProps?.input
           }


### PR DESCRIPTION
## Description
Modifies the positioning of the `<FlagMenu />` to appears below the input field rather than beneath the helper text of the `<TextField />`. 

Fix https://github.com/viclafouch/mui-tel-input/issues/182

![image](https://github.com/user-attachments/assets/73ef8ab0-6009-4070-ac8d-9c4ca1928e70)

## Why
This overlay design makes the dropdown more intuitive and visually consistent with common UI patterns.

## Changes
- By explicitly moving `ref: anchorRef`  inside `slotProps` > `input`, `<FlagMenu />` is anchoring to the input element ignoring the helperText visual space