### PR TITLE
feat: add formatterPerCountry prop for custom phone number formatting

### DIFF
--- a/docs/docs/api-reference.md
+++ b/docs/docs/api-reference.md
@@ -32,7 +32,6 @@ The callback gives you **2 parameters**:
 ### Example
 
 ```tsx
-
 const handleChange = (value, info) => {
   /**
   value: "+33123456789"
@@ -59,8 +58,50 @@ Sets the selected country on component mount
 ### Example
 
 ```tsx
-
 <MuiTelInput defaultCountry="DE" />
+```
+
+## `formatterPerCountry`
+
+- Type: `Partial<Record<MuiTelInputCountry, (value: string) => string>>`
+- Default: `undefined`
+
+Provide a custom formatter for specific countries to avoid using `libphonenumber-js`. The key is the ISO country code, and the value is a formatting function.
+
+### Example
+
+```tsx
+// Format the number to +1 (###) ###-#### for CA only
+const formatterPerCountry = {
+  CA: (value: string) => {
+    if (value.startsWith('+1') && value.length > 2) {
+      const digits = value.replace(/^\+1/, '').replace(/\D/g, '')
+      let formatted = '+1'
+
+      if (digits.length === 0) {
+        return formatted
+      }
+
+      if (digits.length > 0 && digits.length < 4) {
+        formatted += ` (${digits}`
+        return formatted
+      }
+
+      if (digits.length >= 4 && digits.length <= 6) {
+        formatted += ` (${digits.slice(0, 3)}) ${digits.slice(3)}`
+        return formatted
+      }
+
+      if (digits.length > 6) {
+        formatted += ` (${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6, 10)}`
+        return formatted
+      }
+    }
+    return value
+  }
+}
+
+<MuiTelInput formatterPerCountry={formatterPerCountry} />
 ```
 
 ## `forceCallingCode`

--- a/src/index.stories.tsx
+++ b/src/index.stories.tsx
@@ -55,6 +55,39 @@ export const Primary: StoryFn<typeof MuiTelInput> = (args) => {
     setState(argsChange[0])
   }
 
+  const formatterPerCountry = {
+    CA: (phoneNumberValue: string) => {
+      if (phoneNumberValue.length > 2) {
+        const digits = phoneNumberValue.replace(/^\+1/, '').replace(/\D/g, '')
+        let formatted = '+1'
+
+        if (digits.length === 0) {
+          return formatted
+        }
+
+        if (digits.length > 0 && digits.length < 4) {
+          formatted += ` (${digits}`
+
+          return formatted
+        }
+
+        if (digits.length >= 4 && digits.length <= 6) {
+          formatted += ` (${digits.slice(0, 3)}) ${digits.slice(3)}`
+
+          return formatted
+        }
+
+        if (digits.length > 6) {
+          formatted += ` (${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6, 10)}`
+
+          return formatted
+        }
+      }
+
+      return phoneNumberValue
+    }
+  }
+
   return (
     <MuiTelInput
       {...rest}
@@ -69,6 +102,7 @@ export const Primary: StoryFn<typeof MuiTelInput> = (args) => {
       defaultCountry="FR"
       preferredCountries={['FR']}
       onChange={handleChange}
+      formatterPerCountry={formatterPerCountry}
     />
   )
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -56,6 +56,7 @@ const MuiTelInput = (props: MuiTelInputProps) => {
     onlyCountries,
     excludedCountries,
     defaultCountry,
+    formatterPerCountry,
     onDoubleClick,
     onFocus,
     onCopy,
@@ -95,6 +96,7 @@ const MuiTelInput = (props: MuiTelInputProps) => {
   } = usePhoneDigits({
     forceCallingCode,
     defaultCountry: validDefaultCountry,
+    formatterPerCountry,
     value: value ?? '',
     onChange,
     excludedCountries,

--- a/src/index.types.ts
+++ b/src/index.types.ts
@@ -54,6 +54,10 @@ type ForceCallingCodeWithDefaultCountry =
       defaultCountry?: MuiTelInputCountry
     }
 
+type FormatterPerCountry = Partial<
+  Record<MuiTelInputCountry, (value: string) => string>
+>
+
 export type MuiTelInputProps = BaseTextFieldProps &
   ForceCallingCodeWithDefaultCountry & {
     excludedCountries?: MuiTelInputCountry[]
@@ -74,4 +78,5 @@ export type MuiTelInputProps = BaseTextFieldProps &
     getFlagElement?: GetFlagElement
     unknownFlagElement?: MuiTelInputFlagElement
     FlagIconButtonProps?: Partial<IconButtonProps>
+    formatterPerCountry?: FormatterPerCountry
   }

--- a/src/shared/hooks/usePhoneDigits.ts
+++ b/src/shared/hooks/usePhoneDigits.ts
@@ -10,10 +10,15 @@ import {
 import { removeOccurrence } from '@shared/helpers/string'
 import type { MuiTelInputInfo, MuiTelInputReason } from '../../index.types'
 
+type FormatterPerCountry = Partial<
+  Record<MuiTelInputCountry, (value: string) => string>
+>
+
 type UsePhoneDigitsParams = {
   value: string
   onChange?: (value: string, info: MuiTelInputInfo) => void
   defaultCountry?: MuiTelInputCountry
+  formatterPerCountry?: FormatterPerCountry
   forceCallingCode: boolean
   disableFormatting: boolean
   excludedCountries?: MuiTelInputCountry[]
@@ -97,6 +102,7 @@ export default function usePhoneDigits({
   value,
   onChange,
   defaultCountry,
+  formatterPerCountry,
   onlyCountries,
   excludedCountries,
   continents,
@@ -146,6 +152,17 @@ export default function usePhoneDigits({
 
   const typeNewValue = (inputValue: string): string => {
     asYouTypeRef.current.reset()
+    const currentCountry = state.isoCode
+
+    if (
+      formatterPerCountry &&
+      currentCountry &&
+      formatterPerCountry[currentCountry]
+    ) {
+      asYouTypeRef.current.input(inputValue)
+
+      return formatterPerCountry[currentCountry]!(inputValue)
+    }
 
     return asYouTypeRef.current.input(inputValue)
   }


### PR DESCRIPTION
# Description

This PR addresses #178 by introducing a new prop, `formatterPerCountry`, enabling custom phone number formatting on a per-country basis. Developers now can bypass using a default formatter from `libphonenumber-js` for specific countries.

## Example

```
const formatterPerCountry = {
  US: (value: string) => {
    // Format +1 (###) ###-####
    // ...implementation...
    return formattedValue
  }
}

<MuiTelInput formatterPerCountry={formatterPerCountry} />
```